### PR TITLE
Code of Conduct and typo-fix

### DIFF
--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -1,6 +1,6 @@
 # Code of Conduct
 
-We value the participation of every member of the o-score project community and want every contributor to have an enjoyable and fulfilling experience. Accordingly, all contributors are expected to show respect and courtesy to other contributors.
+We value the participation of every member of the o-factor project community and want every contributor to have an enjoyable and fulfilling experience. Accordingly, all contributors are expected to show respect and courtesy to other contributors.
 
 We are dedicated to providing a harassment-free learning experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or choice of text editor. We do not tolerate harassment in any form.
 
@@ -27,7 +27,7 @@ Be careful in the words that you choose. Remember that sexist, racist, and other
 
 **Participants asked to stop any harassing behavior are expected to comply immediately.**
 
-If a participant engages in behavior that violates this code of conduct, the o-score project development team may take any action they deem appropriate, including warning the offender or expulsion from the project. To report an issue, please contact [Rotem Botvinik-Nezer](https://github.com/rotemb9)
+If a participant engages in behavior that violates this code of conduct, the o-factor project development team may take any action they deem appropriate, including warning the offender or expulsion from the project. To report an issue, please contact [Rotem Botvinik-Nezer](https://github.com/rotemb9)
 
 ## Attribution
 

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -1,0 +1,34 @@
+# Code of Conduct
+
+We value the participation of every member of the o-score project community and want every contributor to have an enjoyable and fulfilling experience. Accordingly, all contributors are expected to show respect and courtesy to other contributors.
+
+We are dedicated to providing a harassment-free learning experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or choice of text editor. We do not tolerate harassment in any form.
+
+## Our expectations
+
+We expect all contributors to conform to the following Code of Conduct:
+
+* All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate.
+* Be kind to others. Do not insult or put down others.
+* Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate.
+
+Examples of behavior that contributes to a positive environment include:
+* Using welcome and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption discussions, inappropriate physical contact, and unwelcome sexual attention.
+
+Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you.
+
+## Enforcement
+
+**Participants asked to stop any harassing behavior are expected to comply immediately.**
+
+If a participant engages in behavior that violates this code of conduct, the o-score project development team may take any action they deem appropriate, including warning the offender or expulsion from the project. To report an issue, please contact [Rotem Botvinik-Nezer](https://github.com/rotemb9)
+
+## Attribution
+
+This Code fo Conduct was built on the CoC of the [Whitaker Lab](https://github.com/WhitakerLab) and [Mozillia Science Lab](https://github.com/mozillascience/code_of_conduct/blob/master/CODE_OF_CONDUCT.md)

--- a/ContributingGuidelines.md
+++ b/ContributingGuidelines.md
@@ -45,9 +45,9 @@ Once you've identified an issue that you feel you can contribute to, here's how 
 
 1. Describe what you're planning to do as a comment to an issue. Sometimes this can mean making a new issue, such as if you found a bug that you plan to fix for us (thanks!).
 
-	Check in with one of the o-score development team members to make sure you're not overlapping with any current work that is underway, and so that everyone can be on the same page.
+	Check in with one of the o-factor development team members to make sure you're not overlapping with any current work that is underway, and so that everyone can be on the same page.
 
-2. [Fork](https://help.github.com/articles/fork-a-repo/) (aka make a copy of) the o-score repository to your own Github account.
+2. [Fork](https://help.github.com/articles/fork-a-repo/) (aka make a copy of) the o-factor repository to your own Github account.
 
 	You can now do whatever you want with this copy of the project, and you won't mess up anyone else's work in the master repository by accident.
 
@@ -59,9 +59,9 @@ Once you've identified an issue that you feel you can contribute to, here's how 
 
 4. Submit a [pull request](https://help.github.com/articles/about-pull-requests/).
 
-	Someone in the o-score development team will review your changes, discuss them with you if necessary, and hopefully merge them in! Note that you don't have to be ready to merge to make a pull request. Early submissions of pull requests can help us keep track of progress and help you to get earlier feedback.
+	Someone in the o-factor development team will review your changes, discuss them with you if necessary, and hopefully merge them in! Note that you don't have to be ready to merge to make a pull request. Early submissions of pull requests can help us keep track of progress and help you to get earlier feedback.
 
 **Yay! Thanks for your help!**
 
-## Acknowledgments
+## Attribution
 The format and content of these guidelines were adapted from those of the [WhitakerLab](https://github.com/WhitakerLab).


### PR DESCRIPTION
Drafted code of conduct; realized I had been referring to this as the o-score instead of the o-factor so fixed that in Contributing guidelines